### PR TITLE
Fixed db.lst being overwritten all the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,18 @@ Documentation
 
 ### Configure backups
 Create file inside the `/lst` folder called `folders.lst`.
-The script reads for directories/files to backup. Input list of all folders to backup in one row:
+The script reads for directories/files to backup. Input list of all folders to backup, one folder per line:
 
-		/var/log/ /var/www/ /usr/files/ /tftpd/
+		/var/log/
+        /var/www/
+        /usr/files/
+        /tftpd/
+        
+Create file inside the `/lst` folder called `db.lst`.
+The script reads for MySQL schemas to backup, if `SQL_BACKUP_ALL` is changed to `false`. Input list of all schemas to backup, one schema per line:
+
+		wordpress
+        phpmyadmin
 
 ### How backup files are saved
 all backups are saved by default inside your `workdir`/backup folder. each backup inside a seperate subdirectory.

--- a/backup.sh
+++ b/backup.sh
@@ -14,9 +14,17 @@
 # --------------------------------------------------------
 
 function checkLists {
-    if ! [ -f $backuplistfile ] ; then
-        echo "Missing backup Listfile. create $backuplistfile"
-        exit
+    if $BACKUP_MYSQL ; then
+        if ! [ -f $dblistfile ] ; then
+            echo "Missing MySQL backup Listfile. create $dblistfile"
+            exit 1;
+        fi;
+    fi;
+    if $BACKUP_USERFILES ; then
+        if ! [ -f $backuplistfile ] ; then
+            echo "Missing backup Listfile. create $backuplistfile"
+            exit 1;
+        fi;
     fi;
 }
 
@@ -82,20 +90,21 @@ function shiftBackups {
 }
 
 function dumpSQL {
-    printf "Regenerating DB list file.. ";
     if $WRITE_CHANGES && $BACKUP_MYSQL ; then
-        mysql -u $SQL_USER -p$SQL_PASSWD -Bse 'show databases' > $listfile
-        printf "Dumping SQL Databases.. ";
-        cat $listfile | while read line
+        if $SQL_BACKUP_ALL ; then
+            printf "Regenerating DB list file.. ";
+            mysql -u $SQL_USER -p$SQL_PASSWD -Bse 'show databases' > $dblistfile
+        fi;
+        echo "Dumping SQL Databases.. ";
+        cat $dblistfile | while read line
         do
             dbname=$line
+            echo $dbname
             if [ $line != "information_schema" ] ;
             then
                 mysqldump --events --ignore-table=mysql.events -u $SQL_USER -p$SQL_PASSWD $dbname > $tempdir/$dbname.sql
             fi
         done
-        printf "Ok\n"
-    else printf "Skipping\n"
     fi;
 }
 

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -20,16 +20,17 @@ BACKUP_DAILY_ONLY_ONCE=true		# Allow only one backup per day
 workdir=/scripts/Centos-Backup-Script
 
 # backup source settings
-listfile=$workdir/lst/db.lst				# list of mysql database schemas to backup (1 per line)
-backuplistfile=$workdir/lst/folders.lst	# list of files to backup (1 per line)
+dblistfile=$workdir/lst/db.lst				# list of mysql database schemas to backup (1 per line)
+backuplistfile=$workdir/lst/folders.lst	    # list of files to backup (1 per line)
 
 # SQL settings
 SQL_USER="user"					# MYSQL User
 SQL_PASSWD="password"			# MYSQL Password
+SQL_BACKUP_ALL=true             # If true, db.lst is overwritten with all MYSQL schemas, backing them all up
 
 # output settings
 tempdir=$workdir/temp					# temporary folder
 backupdir=$workdir/backup				# place for the .gz files
-filename=backup-$(date +%Y%m%d).tgz	# backup .tgz file-name
+filename=backup-$(date +%Y%m%d).tgz	    # backup .tgz file-name
 logdir=/var/log/backup                	# where to store log files
 showfsz=true							# Show df -h at end


### PR DESCRIPTION
Fixed db.lst being overwritten all the time, preventing specific schemas from being selected
Added setting SQL_BACKUP_ALL which uses the old behavior (defaults to true)
Fixed checkLists always checking backuplistfile even if BACKUP_USERFILES is false
Added a check against the dblistfile to checkLists when BACKUP_MYSQL is true
Renamed listfile to dblistfile to reduce confusion
Changed output of dumpSQL to align with directory backup process (name schemas as they are dumped, silent if skipped)
Update the README.md instructions on setting up the .lst files to reflect the current setup