### PR TITLE
Add quiet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,18 @@ Documentation
 
 ### Configure backups
 Create file inside the `/lst` folder called `folders.lst`.
-The script reads for directories/files to backup. Input list of all folders to backup in one row:
+The script reads for directories/files to backup. Input list of all folders to backup, one folder per line:
 
-		/var/log/ /var/www/ /usr/files/ /tftpd/
+		/var/log/
+        /var/www/
+        /usr/files/
+        /tftpd/
+        
+Create file inside the `/lst` folder called `db.lst`.
+The script reads for MySQL schemas to backup, if `SQL_BACKUP_ALL` is changed to `false`. Input list of all schemas to backup, one schema per line:
+
+		wordpress
+        phpmyadmin
 
 ### How backup files are saved
 all backups are saved by default inside your `workdir`/backup folder. each backup inside a seperate subdirectory.

--- a/backup.sh
+++ b/backup.sh
@@ -14,9 +14,17 @@
 # --------------------------------------------------------
 
 function checkLists {
-    if ! [ -f $backuplistfile ] ; then
-        echo "Missing backup Listfile. create $backuplistfile"
-        exit
+    if $BACKUP_MYSQL ; then
+        if ! [ -f $dblistfile ] ; then
+            echo "Missing MySQL backup Listfile. create $dblistfile"
+            exit 1;
+        fi;
+    fi;
+    if $BACKUP_USERFILES ; then
+        if ! [ -f $backuplistfile ] ; then
+            echo "Missing backup Listfile. create $backuplistfile"
+            exit 1;
+        fi;
     fi;
 }
 
@@ -82,20 +90,21 @@ function shiftBackups {
 }
 
 function dumpSQL {
-    printf "Regenerating DB list file.. ";
     if $WRITE_CHANGES && $BACKUP_MYSQL ; then
-        mysql -u $SQL_USER -p$SQL_PASSWD -Bse 'show databases' > $listfile
-        printf "Dumping SQL Databases.. ";
-        cat $listfile | while read line
+        if $SQL_BACKUP_ALL ; then
+            printf "Regenerating DB list file.. ";
+            mysql -u $SQL_USER -p$SQL_PASSWD -Bse 'show databases' > $dblistfile
+        fi;
+        echo "Dumping SQL Databases.. ";
+        cat $dblistfile | while read line
         do
             dbname=$line
+            echo $dbname
             if [ $line != "information_schema" ] ;
             then
                 mysqldump --events --ignore-table=mysql.events -u $SQL_USER -p$SQL_PASSWD $dbname > $tempdir/$dbname.sql
             fi
         done
-        printf "Ok\n"
-    else printf "Skipping\n"
     fi;
 }
 

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -20,16 +20,17 @@ BACKUP_DAILY_ONLY_ONCE=true		# Allow only one backup per day
 workdir=/scripts/Centos-Backup-Script
 
 # backup source settings
-listfile=$workdir/lst/db.lst				# list of mysql database schemas to backup (1 per line)
-backuplistfile=$workdir/lst/folders.lst	# list of files to backup (1 per line)
+dblistfile=$workdir/lst/db.lst				# list of mysql database schemas to backup (1 per line)
+backuplistfile=$workdir/lst/folders.lst	    # list of files to backup (1 per line)
 
 # SQL settings
 SQL_USER="user"					# MYSQL User
 SQL_PASSWD="password"			# MYSQL Password
+SQL_BACKUP_ALL=true             # If true, db.lst is overwritten with all MYSQL schemas, backing them all up
 
 # output settings
 tempdir=$workdir/temp					# temporary folder
 backupdir=$workdir/backup				# place for the .gz files
-filename=backup-$(date +%Y%m%d).tgz	# backup .tgz file-name
+filename=backup-$(date +%Y%m%d).tgz	    # backup .tgz file-name
 logdir=/var/log/backup                	# where to store log files
 showfsz=true							# Show df -h at end

--- a/settings.cfg.example
+++ b/settings.cfg.example
@@ -7,6 +7,7 @@
 # General settings
 DISABLED=false			# Disable Script from run. Set to true to disable the backup
 WRITE_CHANGES=false		# Test mode (no hard-disk writes). Set to true to actually save the backup
+QUIET=false             # Set to true to silence all non-error output
 
 # Backup Options
 BACKUP_USERFILES=true			# Allow backing up files from the backuplistfile


### PR DESCRIPTION
This adds a `QUIET` option to the settings which makes only errors print, defaults to false

The rational behind this is that when I run my cron jobs, crond will email me any output from my jobs. I, and I am sure a decent number of other sysadmins, prefer to not get emails on every run of certain jobs, but only when there is an error on those specified jobs. No news is good news as they say.